### PR TITLE
Captialized SerialVersionUID as described in issue #5

### DIFF
--- a/src/banking/primitive/core/Checking.java
+++ b/src/banking/primitive/core/Checking.java
@@ -1,8 +1,8 @@
 package banking.primitive.core;
 
 public class Checking extends Account {
-
-	private static final long serialVersionUID = 11L;
+	//qbecker issue #5 fix
+	private static final long SerialVersionUID = 11L;
 	private int numWithdraws = 0;
 	
 	private Checking(String name) {


### PR DESCRIPTION
Fixed issue #5 by capitalizing SerialVersionUID according to coding standards